### PR TITLE
ci: Fix deployment bug in Github Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   pipeline:
@@ -20,19 +20,20 @@ jobs:
     - run: mvn -q javadoc:javadoc
 
     - name: Prepare deploy
-      if: github.ref == 'refs/head/master'
+      if: github.ref == 'refs/heads/master'
       run: |
         git config --global user.email "actions@github"
         git config --global user.name "Github Actions"
         mv target/site/apidocs /tmp/
+        git pull
         git checkout gh-pages
         rm -rf docs
         mv /tmp/apidocs docs
         git add docs
-        git commit -m "CI: $(git log HEAD --no-decorate --oneline -1 --abbrev-commit)"
+        git commit -m "CI: $(git log master --no-decorate --oneline -1 --abbrev-commit)"
 
     - name: Deploy
-      if: github.ref == 'refs/head/master' && success()
+      if: github.ref == 'refs/heads/master' && success()
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.AUTH_TOKEN }}


### PR DESCRIPTION
s:refs/head/master:refs/heads/master:g
This also deploys the javadoc to GitHub pages