### PR TITLE
net: fixes #4, implements a jetty HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ $ mvn test
 $ mvn package
 ```
 
+## Running the server
+```bash
+# Running the server
+$ mvn compile exec:java
+```
 ## Generating the documentation
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,17 @@
                 <configuration>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution><goals><goal>java</goal></goals></execution>
+                </executions>
+                <configuration>
+                    <mainClass>dd2480.group4.Main</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -44,6 +55,16 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.5.2</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>9.4.26.v20200117</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>9.4.26.v20200117</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/dd2480/group4/Main.java
+++ b/src/main/java/dd2480/group4/Main.java
@@ -1,7 +1,17 @@
 package dd2480.group4;
+import dd2480.group4.execute.Runner;
+import dd2480.group4.net.RequestHandler;
+import org.eclipse.jetty.server.Server;
 
 public class Main {
     public static void main(String[] args) {
-        System.out.println("Hello, world!");
+        Server server = new Server(8004);
+        try {
+            server.setHandler(new RequestHandler(new Runner()));
+            server.start();
+            server.join();
+        } catch(Exception e) {
+            System.err.println(e);
+        }
     }
 }

--- a/src/main/java/dd2480/group4/execute/Executor.java
+++ b/src/main/java/dd2480/group4/execute/Executor.java
@@ -1,0 +1,8 @@
+package dd2480.group4.execute;
+
+import dd2480.group4.net.BuildRequest;
+
+public interface Executor {
+
+    void runBuild(BuildRequest req);
+}

--- a/src/main/java/dd2480/group4/execute/Runner.java
+++ b/src/main/java/dd2480/group4/execute/Runner.java
@@ -1,7 +1,13 @@
 package dd2480.group4.execute;
 
+import dd2480.group4.net.BuildRequest;
+
 /**
  * Responsible for running the individual builds.
  */
-public class Runner {
+public class Runner implements Executor {
+    @Override
+    public void runBuild(BuildRequest req) {
+
+    }
 }

--- a/src/main/java/dd2480/group4/net/API.java
+++ b/src/main/java/dd2480/group4/net/API.java
@@ -1,7 +1,0 @@
-package dd2480.group4.net;
-
-/**
- * A class which defines the handlers and endpoints for the web hooks
- */
-public class API {
-}

--- a/src/main/java/dd2480/group4/net/BuildRequest.java
+++ b/src/main/java/dd2480/group4/net/BuildRequest.java
@@ -5,4 +5,8 @@ package dd2480.group4.net;
  * TODO: should model the repository at a given state (i.e. url, commit hash, branch, time and date)
  */
 public class BuildRequest {
+    String json;
+    public BuildRequest(String json) {
+        this.json = json;
+    }
 }

--- a/src/main/java/dd2480/group4/net/RequestHandler.java
+++ b/src/main/java/dd2480/group4/net/RequestHandler.java
@@ -1,0 +1,38 @@
+package dd2480.group4.net;
+
+import dd2480.group4.execute.Executor;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A class which defines the handlers and endpoints for the web hooks
+ */
+public class RequestHandler extends AbstractHandler {
+
+    Executor executor;
+
+    public RequestHandler(Executor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public void handle(String target,
+                       Request baseRequest,
+                       HttpServletRequest request,
+                       HttpServletResponse response) throws IOException
+    {
+        response.setContentType("text/html;charset=utf-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+        var bytes = request.getInputStream().readAllBytes();
+        var json = new String(bytes, StandardCharsets.UTF_8);
+        var buildRequest = new BuildRequest(json);
+        executor.runBuild(buildRequest);
+        baseRequest.setHandled(true);
+        response.getWriter().println(json);
+    }
+}

--- a/src/main/java/dd2480/group4/net/Server.java
+++ b/src/main/java/dd2480/group4/net/Server.java
@@ -1,7 +1,0 @@
-package dd2480.group4.net;
-
-/**
- * The class responsible for listening and handling connections
- */
-public class Server {
-}

--- a/src/test/java/dd2480/group4/net/APITest.java
+++ b/src/test/java/dd2480/group4/net/APITest.java
@@ -1,7 +1,0 @@
-package dd2480.group4.net;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class APITest {
-
-}

--- a/src/test/java/dd2480/group4/net/RequestHandlerTest.java
+++ b/src/test/java/dd2480/group4/net/RequestHandlerTest.java
@@ -1,0 +1,65 @@
+package dd2480.group4.net;
+
+import dd2480.group4.execute.Executor;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RequestHandlerTest {
+
+    @Test
+    public void doHandle() throws Exception {
+        var executor = new Executor() {
+            public BuildRequest request;
+
+            @Override
+            public void runBuild(BuildRequest req) {
+                this.request = req;
+
+            }
+        };
+        var server = newServer(executor);
+        var http = httpPost(server, "foo");
+        assertEquals(http.getResponseCode(), HttpStatus.OK_200, "response code should be OK");
+        assertEquals("foo", executor.request.json, "Excepted json to be set to POST data");
+
+        server.stop();
+    }
+
+    private Server newServer(Executor executor) {
+        var rng = ThreadLocalRandom.current();
+        var port = rng.nextInt(1000) + 8000;
+        Server server = new Server(port);
+        server.setHandler(new RequestHandler(executor));
+        try {
+            server.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return server;
+    }
+
+    private HttpURLConnection httpPost(Server server, String json) throws IOException {
+        byte[] data = json.getBytes();
+        HttpURLConnection http = (HttpURLConnection) new URL("http", "localhost", server.getURI().getPort(), "/").openConnection();
+        http.setDoOutput(true);
+        http.setInstanceFollowRedirects(false);
+        http.setRequestMethod("POST");
+        http.setRequestProperty("Content-Type", "application/json");
+        http.setRequestProperty("charset", "utf-8");
+        http.setRequestProperty("Content-Length", Integer.toString(data.length));
+        http.setUseCaches(false);
+        try (DataOutputStream wr = new DataOutputStream(http.getOutputStream())) {
+            wr.write(data);
+        }
+        return http;
+    }
+}

--- a/src/test/java/dd2480/group4/net/ServerTest.java
+++ b/src/test/java/dd2480/group4/net/ServerTest.java
@@ -1,7 +1,0 @@
-package dd2480.group4.net;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class ServerTest {
-
-}


### PR DESCRIPTION
The jetty HTTP server runs on port 8004 and expects POST
request to the root URL. BuildRequest is a dummy as well as Runner
instead of the actual implementations.