### PR TITLE
ci: Use deploy keys instead of access tokens

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,23 +18,16 @@ jobs:
     - run: mvn -q test
     - run: mvn -q package
     - run: mvn -q javadoc:javadoc
-
-    - name: Prepare deploy
-      if: github.ref == 'refs/heads/master'
-      run: |
-        git config --global user.email "actions@github"
-        git config --global user.name "Github Actions"
-        mv target/site/apidocs /tmp/
-        git pull
-        git checkout gh-pages
-        rm -rf docs
-        mv /tmp/apidocs docs
-        git add docs
-        git commit -m "CI: $(git log master --no-decorate --oneline -1 --abbrev-commit)"
+    - run: touch ./target/site/apidocs/.nojekyll
 
     - name: Deploy
       if: github.ref == 'refs/heads/master' && success()
-      uses: ad-m/github-push-action@master
+      uses: peaceiris/actions-gh-pages@v2.10.1
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./target/site/apidocs
       with:
-        github_token: ${{ secrets.AUTH_TOKEN }}
-        branch: gh-pages
+        commitMessage: ${{ github.event.head_commit.message }}
+        username: "Github Actions"
+        useremail: "actions@github"


### PR DESCRIPTION
Due to a bug, pushing to Github Pages from a Github server does not trigger a GitHub pages
rebuild even if the gh-pages branch were updated. To remedy this we
instead move to a deploy key with push access, as well as using a
designated Action for deploying to gh-pages. Fixes #16